### PR TITLE
Quote versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
-        poetry-version: [1.0, 1.1.11]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        poetry-version: ["1.0", "1.1.11"]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Previously, the python version 3.10 was parsed as a 3.1 because the number 3.10 is the same as 3.1.

Quoting it as a string fixes the parsing, where it correctly reads it as "3.10"